### PR TITLE
fix-project-destination

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ _Please note that all scripts on my GitHub account (or shared elsewhere) are wor
 
 ## Known issues
 
-- If no placeholders are included in the template's note, the script won't currently prompt the user for a due/defer date when it should. This is a bug.
+Refer to the 'issues' in this repo for known issues and planned changes/enhancements.
 
 # Installation & Set-Up
 
@@ -68,7 +68,7 @@ This function takes a template as input and returns the parent folder to be used
 
 This function takes a template and a destination (a folder or project) as input. It:
 
-1. Copies the template to the specified destination and makes it active.
+1. Copies the template to the specified destination and makes it active. (If the template is copied to a project it is created as an action group.)
 2. For the newly created project, or for the project that the template is duplicated to:
    1. For each placeholder where a value is specified (in the form `«Placeholder»:Value`):
       - Replaces all instances of that placeholder in the project/task names
@@ -80,4 +80,5 @@ This function takes a template and a destination (a folder or project) as input.
       - Replaces all instances of that placeholder in the project/task names
       - If there are any tags in this format, replaces these with the best match (if there are no matches found, a tag will be created, but note that this uses Omnifocus' built-in search so if there is a similar tag this may be applied instead)
       - Includes the replacement value in the note of the created project (in the form `«Placeholder»:Value`)
+      - _Note:_ If a template is copied to an existing project, any placeholders in the project's note will be used first before prompting for further information.
 3. If the template project has a due date, prompts the user for a new due date and adjusts the dates of all tasks within the created project/action group accordingly. If there is no due date but there is a defer date, this is used instead.

--- a/Resources/templateLibrary.js
+++ b/Resources/templateLibrary.js
@@ -66,32 +66,42 @@
     askAboutOptionalTasks(optTasks)
 
     // IDENTIFY AND REPLACE TEXT VARIABLES DECLARED IN TEMPLATE TASK NOTE
-    // value specified
-    const iterator1 = project.note.matchAll(/«(.*?)»:(.*?)$/gm)
-    if (typeof iterator1[Symbol.iterator] === 'function') {
-      const specifiedPlaceholders = [...iterator1]
-      if (specifiedPlaceholders !== null) {
-        specifiedPlaceholders.forEach((placeholder) => {
-          replace(project, placeholder[1], placeholder[2])
-        })
+
+    /* match and replace placeholders with values specified in specific task's note */
+    function replaceValuesSpecifiedIn (task) {
+      const iterator1 = task.note.matchAll(/«(.*?)»:(.*?)$/gm)
+      if (typeof iterator1[Symbol.iterator] === 'function') {
+        const specifiedPlaceholders = [...iterator1]
+        if (specifiedPlaceholders !== null) {
+          specifiedPlaceholders.forEach((placeholder) => {
+            replace(project, placeholder[1], placeholder[2])
+          })
+        }
       }
     }
 
-    // no value specified
-    const iterator2 = project.note.matchAll(/«(.*?)»$/gm)
-    if (
-      iterator2 !== null &&
-      typeof iterator2[Symbol.iterator] === 'function'
-    ) {
-      console.log("in if and shouldn't be...")
-      let placeholders = [...iterator2]
-      if (placeholders !== null) {
-        placeholders = await askForValues(placeholders)
-        placeholders.forEach((placeholder) => {
-          replace(project, placeholder[0], placeholder[1])
-        })
+    async function replaceValuesNotSpecifiedIn (task) {
+      const iterator2 = task.note.matchAll(/«(.*?)»$/gm)
+      if (
+        iterator2 !== null &&
+        typeof iterator2[Symbol.iterator] === 'function'
+      ) {
+        let placeholders = [...iterator2]
+        if (placeholders !== null) {
+          placeholders = await askForValues(placeholders)
+          placeholders.forEach((placeholder) => {
+            replace(project, placeholder[0], placeholder[1])
+          })
+        }
       }
     }
+
+    // replace with values from project, then from created group
+    replaceValuesSpecifiedIn(project.task)
+    replaceValuesSpecifiedIn(created)
+
+    // no value specified
+    replaceValuesNotSpecifiedIn(created)
 
     function replace (project, placeholder, replacement) {
       const regex = new RegExp(`«${placeholder}».*$`, 'gm')

--- a/Resources/templateLibrary.js
+++ b/Resources/templateLibrary.js
@@ -50,19 +50,19 @@
   }
 
   templateLibrary.createFromTemplate = async (template, destination) => {
-    // CREATE NEW PROJECT
+    // create from template
     let created, project
     if (destination instanceof Project) {
-      created = duplicateTasks(template.tasks, destination)[0]
+      created = duplicateTasks([template.task], destination)[0]
       project = destination
     } else {
       created = duplicateSections([template], destination)[0]
       project = created
+      project.status = Project.Status.Active // make status active if not already
     }
-    created.status = Project.Status.Active // make status active
 
     // ASK ABOUT OPTIONAL TASKS
-    const optTasks = project.flattenedTasks.filter(task => task.note.includes('$OPTIONAL'))
+    const optTasks = created.flattenedTasks.filter(task => task.note.includes('$OPTIONAL'))
     askAboutOptionalTasks(optTasks)
 
     // IDENTIFY AND REPLACE TEXT VARIABLES DECLARED IN TEMPLATE TASK NOTE

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "identifier": "com.KaitlinSalzke.Templates",
   "author": "Kaitlin Salzke",
   "description": "An OmniFocus plugin that enables projects to be created from templates",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "actions": [
     {
       "identifier": "createFromTemplate"


### PR DESCRIPTION
Several fixes where adding templates to a project:
- Adds as action group, rather than adding subtasks.
- Prompts for placeholder and date information - fixes #3.
- Does not prompt if placeholder information is already in project note, instead uses that info.