### PR TITLE
Set the next review date of newly-created projects

### DIFF
--- a/Templates.omnifocusjs/Resources/templateLibrary.js
+++ b/Templates.omnifocusjs/Resources/templateLibrary.js
@@ -115,7 +115,32 @@
       project = created.containingProject
     }
 
-    if (created instanceof Project) created.status = Project.Status.Active // make status active if not already active
+    if (created instanceof Project) {
+      created.status = Project.Status.Active; // make status active if not already active
+
+      // Set the review date to today plus the review interval, on the
+      // assumption that the user is probably going to review the project as
+      // soon as it's created.  If we don't do this, the review date of the
+      // original project will be used instead, which might be far in the past
+      // (e.g. when the template was first created).
+      const ri = created.reviewInterval;
+      const nextReviewDate = new Date();
+      switch (ri.unit) {
+        case 'days':
+          nextReviewDate.setDate(nextReviewDate.getDate() + ri.steps);
+          break;
+        case 'weeks':
+          nextReviewDate.setDate(nextReviewDate.getDate() + 7 * ri.steps);
+          break;
+        case 'months':
+          nextReviewDate.setMonth(nextReviewDate.getMonth() + ri.steps);
+          break;
+        case 'years':
+          nextReviewDate.setFullYear(nextReviewDate.getFullYear() + ri.steps);
+          break;
+      }
+      created.nextReviewDate = nextReviewDate;
+    }
 
     // ASK ABOUT OPTIONAL TASKS
     const optTasks = created.flattenedTasks.filter(task => task.note.includes('$OPTIONAL'))


### PR DESCRIPTION
Set the next review date of a newly-created project to <review interval> days/weeks/months/years after today.

If we don't do this, the newly-created project will inherit the review date from the template, which is probably far in the past (i.e. whenever the template was created), and the newly-created project will immediately appear in the user's list of projects to review. This is probably not what the user wants, since they just created the project and will presumably review it after creation.

Testing:
- Manually tested creation with all the project intervals (days, weeks, months, years)
- Tested with weird/long intervals (e.g. confirmed that "10 days" gets added correctly)
- Tested creation of action groups (to be sure the new logic doesn't introduce any crashes when it shouldn't be running)